### PR TITLE
Fix #5 - Credentials file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip3 install git+https://github.com/avanzzzi/hypy.git
 
 ## Configuration
 To configure Hypy, create the file '~/.hypy.conf'. You can use hypy.conf.example that comes with the package to get a starting point or use the contents below.
-These options can be overriden in the command line if needed.
+These options can be overriden in the command line if needed. Also, you can generate this file using `hypy credentials create`
 ```ini
 [credentials]
 host = <server name in domain>
@@ -70,22 +70,23 @@ Options:
   --help                   Show this message and exit.
 
 Commands:
-  connect   Connect to virtual machine identified by...
-  create    Create a new snapshot with vm's current state
-  delete    Delete a machine's snapshot by name
-  list      List virtual machines and its indexes
-  ls        List updated virtual machines and its indexes
-  pause     Pause virtual machine identified by index
-  restore   Restore virtual machine snapshot
-  resume    Resume (paused) virtual machine identified by...
-  save      Save virtual machine identified by index
-  snap      Manage virtual machine snapshots
-  snaps     List virtual machine snapshots
-  start     Start virtual machine identified by index
-  status    Show virtual machine current status
-  stop      Stop virtual machine identified by index
-  switch    Manage virtual network switches in the...
-  switches  List avaiable virtual network switches in the...
+  connect      Connect to virtual machine identified by index
+  create       Create a new snapshot with vm's current state
+  credentials  Generate or update the credentials file
+  delete       Delete a machine's snapshot by name
+  list         List virtual machines and its indexes
+  ls           List updated virtual machines and its indexes
+  pause        Pause virtual machine identified by index
+  restore      Restore virtual machine snapshot
+  resume       Resume (paused) virtual machine identified by index
+  save         Save virtual machine identified by index
+  snap         Manage virtual machine snapshots
+  snaps        List virtual machine snapshots
+  start        Start virtual machine identified by index
+  status       Show virtual machine current status
+  stop         Stop virtual machine identified by index
+  switch       Manage virtual network switches in the Hyper-V server.
+  switches     List available virtual network switches in the Hyper-V server
 ```
 
 If you need help on any subcommand, run `hypy.py COMMAND --help`.

--- a/hypy/__main__.py
+++ b/hypy/__main__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # coding: utf-8
+from hypy.cli_credentials import credentials
 from hypy.cli_main import cli
 from hypy.cli_snap import create, delete, restore, snap, snaps
 from hypy.cli_switch import switch, switches
@@ -13,4 +14,5 @@ cli.add_command(create)
 cli.add_command(restore)
 cli.add_command(delete)
 
+cli.add_command(credentials)
 cli()

--- a/hypy/cli_credentials.py
+++ b/hypy/cli_credentials.py
@@ -1,0 +1,31 @@
+import click
+from hypy.modules import config
+
+
+@click.group('credentials', help='Generate or update the credentials file')
+def credentials():
+    """Manage config file of the Hyper-V Python."""
+    pass
+
+
+@credentials.command('create', help='Create hypy configuration file')
+@click.option('--user', '-u', prompt=True, help='Username in hyper-v server')
+@click.option('--passw', '-p', prompt=True, hide_input=True,
+              help='Password in hyper-v server')
+@click.option('--domain', '-d', prompt=True, help='Domain name')
+@click.option('--host', '-m', prompt=True, help='Hyper-V server hostname/ip address')
+@click.option('--proto', '-t', prompt=True, help='Protocol to be used',
+              type=click.Choice(['ssh', 'winrm'], case_sensitive=False))
+@click.option('--port', '-P', prompt=True, help='SSH port', default='22')
+@click.option('--sync', '-s', prompt=True,
+              help='Time, in hours, between autosync', default='2')
+def generate_config_file(user, passw, domain, host, proto, port, sync):
+    config.generate_credentials(user, passw, domain, host, proto, port, sync)
+
+
+@credentials.command('update',
+                     help='Update the password encryption of the hypy configuration file')
+@click.option('--passw', '-p', prompt='Password. Blank keeps last password',
+              hide_input=True, default='', help='Password in hyper-v server')
+def update_password(passw):
+    config.encrypt_password(passw)

--- a/hypy/cli_main.py
+++ b/hypy/cli_main.py
@@ -4,21 +4,23 @@ import click
 from hypy.modules import cache, config, hvclient, printer
 
 
-@click.group('cli')
+@click.group('cli', invoke_without_command=True)
 @click.option('--user', '-u', help='Username in hyper-v server')
 @click.option('passw', '--pass', '-p', help='Password in hyper-v server')
 @click.option('--domain', '-d', help='Domain name')
 @click.option('--host', '-m', help='Hyper-V server hostname/ip address')
 @click.option('--proto', '-t', help='Protocol to be used',
               type=click.Choice(['ssh', 'winrm']))
-def cli(user, passw, domain, host, proto):
+@click.pass_context
+def cli(ctx, user, passw, domain, host, proto):
     """
     Multiplataform Hyper-V Manager using Python and FreeRDP
     """
-    config.load(user, passw, domain, host, proto)
-    hvclient.config = config.configuration
-    cache.current_host = config.configuration['host']
-    cache.sync_interval = config.configuration['sync_interval']
+    if ctx.invoked_subcommand != 'credentials':
+        config.load(user, passw, domain, host, proto)
+        hvclient.config = config.configuration
+        cache.current_host = config.configuration['host']
+        cache.sync_interval = config.configuration['sync_interval']
 
 
 @cli.command("status", help='Show virtual machine current status')

--- a/hypy/cli_switch.py
+++ b/hypy/cli_switch.py
@@ -8,7 +8,7 @@ def switch():
     pass
 
 
-@switch.command('ls', help='List avaiable virtual network switches in the Hyper-V server')
+@switch.command('ls', help='List available virtual network switches in the Hyper-V server')
 def list_switches():
     rs = hvclient.list_switches()
     switches = hvclient.parse_result(rs)
@@ -40,7 +40,7 @@ def get_switch(by_name, ident):
 #
 # Aliases
 #
-@click.command('switches', help='List avaiable virtual network switches in the Hyper-V server')
+@click.command('switches', help='List available virtual network switches in the Hyper-V server')
 @click.pass_context
 def switches(ctx):
     ctx.forward(list_switches)

--- a/hypy/modules/cache.py
+++ b/hypy/modules/cache.py
@@ -96,7 +96,7 @@ def update_cache(vms_json: dict):
 
 def need_update() -> bool:
     """
-    Cheks if cache needs update based on cache file modification date.
+    Checks if cache needs update based on cache file modification date.
 
     Returns:
         True if the cache file is older than sync interval in hours.

--- a/hypy/modules/config.py
+++ b/hypy/modules/config.py
@@ -1,6 +1,7 @@
 """
 Hypy configuration manager module
 """
+import base64
 import configparser
 from os.path import expanduser
 
@@ -8,7 +9,75 @@ CONFIG_FILE_LOCATION = expanduser('~/.hypy.conf')
 configuration = None
 
 
-def load(user: str, passw: str, domain: str, host: str, proto: str):
+def encrypt_password(passw: str) -> None:
+    """
+    Update the password with a encrypted version of the passed in command line.
+
+    Args:
+        passw: Password passed as command line option.
+    """
+    try:
+        config = configparser.ConfigParser()
+        config.read(CONFIG_FILE_LOCATION)
+
+        secret = config['credentials'].get('pass', '')
+
+        if passw or not secret.startswith("b'"):
+            config['credentials']['pass'] = str(base64.b64encode(passw.encode()))
+
+            with open(CONFIG_FILE_LOCATION, 'w') as configfile:
+                config.write(configfile)
+    except KeyError:
+        print("Please, configure your credentials file - hypy.conf")
+        print(CONFIG_FILE_LOCATION)
+        exit(1)
+
+
+def generate_credentials(
+    user: str,
+    passw: str,
+    domain: str,
+    host: str,
+    proto: str,
+    ssh_port: str,
+    sync_interval: str,
+) -> None:
+    """
+    Generate config file from command line inputs create the configuration.
+
+    Args:
+        user: User passed as command line option.
+        passw: Password passed as command line option.
+        domain: Domain passed as command line option.
+        host: Host passed as command line option.
+        proto: Protocol passed as command line option.
+        ssh_port: SSH port passed as command line option.
+        sync_interval: Delay time between another sync (hours).
+    """
+    config = configparser.ConfigParser()
+    config['credentials'] = {
+        'user': user,
+        'pass': str(base64.b64encode(passw.encode())),
+        'domain': domain,
+        'host': host,
+    }
+    config['options'] = {
+        'sync_interval': sync_interval,
+        'protocol': proto,
+        'ssh_port': ssh_port,
+    }
+
+    with open(CONFIG_FILE_LOCATION, 'w') as configfile:
+        config.write(configfile)
+
+
+def load(
+    user: str,
+    passw: str,
+    domain: str,
+    host: str,
+    proto: str,
+) -> None:
     """
     Read config file and command line to create the configuration.
 
@@ -27,18 +96,23 @@ def load(user: str, passw: str, domain: str, host: str, proto: str):
 
         credentials = config['credentials']
 
+        if not credentials.get('pass').startswith("b'"):
+            encrypt_password(credentials.get('pass'))
+            config.read(CONFIG_FILE_LOCATION)
+            credentials = config['credentials']
+
         configuration = {'user': credentials['user'],
-                         'pass': credentials['pass'],
+                         'pass': base64.b64decode(eval(credentials['pass'])),
                          'domain': credentials['domain'],
                          'host': credentials['host']}
 
-        if user is not None:
+        if user:
             configuration['user'] = user
-        if passw is not None:
+        if passw:
             configuration['pass'] = passw
-        if domain is not None:
+        if domain:
             configuration['domain'] = domain
-        if host is not None:
+        if host:
             configuration['host'] = host
 
         options = config['options']
@@ -47,7 +121,7 @@ def load(user: str, passw: str, domain: str, host: str, proto: str):
         configuration['protocol'] = options['protocol']
         configuration['ssh_port'] = options['ssh_port']
 
-        if proto is not None:
+        if proto:
             configuration['protocol'] = proto
 
     except KeyError:

--- a/hypy/modules/hvclient.py
+++ b/hypy/modules/hvclient.py
@@ -1,6 +1,6 @@
 import json
 import platform
-from base64 import b64encode
+from base64 import b64encode, b64decode
 from collections import namedtuple
 from subprocess import DEVNULL, PIPE, Popen, TimeoutExpired
 
@@ -24,7 +24,7 @@ def connect(vm_id: str, vm_name: str, vm_index: str):
         vm_index: Index of the vm in the cache file.
     """
     user = config['user']
-    passw = config['pass']
+    passw = b64decode(config['pass'])
     host = config['host']
 
     if platform.uname()[0] == "Windows":
@@ -177,7 +177,7 @@ def create_vm_snapshot(vm_name: str, snap_name: str) -> Response:
 
 def parse_result(rs: Response) -> dict:
     """
-    Parse Respnse object obtained from hyper-v.
+    Parse Response object obtained from hyper-v.
 
     Args:
         rs: Response object with its properties (out, err and return_code).
@@ -350,7 +350,7 @@ def run_cmd_ssh(cmd: str) -> Response:
     ssh_client.load_system_host_keys()
     ssh_client.set_missing_host_key_policy(AutoAddPolicy())
     ssh_client.connect(username=config['user'],
-                       password=config['pass'],
+                       password=b64decode(config['pass']),
                        hostname=config['host'],
                        port=int(config['ssh_port']),
                        allow_agent=False,
@@ -380,7 +380,7 @@ def run_cmd_winrm(cmd: str) -> Response:
                       transport='ntlm',
                       username=r'{}\{}'.format(config['domain'],
                                                config['user']),
-                      password=config['pass'],
+                      password=b64decode(config['pass']),
                       server_cert_validation='ignore')
 
     shell_id = client.open_shell()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hypy3"
-version = "0.3.6"
+version = "0.3.7"
 description = "Multiplataform Hyper-V Manager using Python and FreeRDP"
 authors = ["Gabriel Avanzi <gabriel.avanzi@gmail.com>"]
 license = "GPL-3.0"


### PR DESCRIPTION
Hi @avanzzzi, I would like to contribute to hypy fixing #5.

In this PR I:
- Generate configuration when the user does not have one;
- Obfuscate the password with base64 lib;
- Transparent migration, if a not obfuscated password is used, this code obfuscate it; and
- Also added a function to update the password.

Limitations:
- If the password startswith `b'` it was assumed that was encrypted, in order to not use `eval`. This occurs because when the ~/.hypy.conf configuration file is loaded, all data are strings, and save bytes as str then load this str as bytes is not usual.

Fell free to contact me anytime.

Regarts