### PR TITLE
Fix #26: cert usage flag in freerdp call

### DIFF
--- a/hypy/modules/hvclient.py
+++ b/hypy/modules/hvclient.py
@@ -37,7 +37,7 @@ def connect(vm_id: str, vm_name: str, vm_index: str):
                         '/u:{}'.format(user),
                         '/p:{}'.format(passw),
                         '/t:{} [{}] {}'.format(host, vm_index, vm_name),
-                        '/cert-ignore']
+                        '/cert:ignore']
 
     try:
         handle = Popen(cmd, stdout=DEVNULL, stderr=PIPE)


### PR DESCRIPTION
I just update the flag without retro-compatibility, since it was available in xfreerdp at version 2.0.0, and actually the latest version is 3.8.0.

This PR fix #26 