### PR TITLE
feat: enable window resizing on Linux/Mac via xfreerdp smart-sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,20 @@ Commands:
 If you need help on any subcommand, run `hypy.py COMMAND --help`.
 Further details on subcommands: https://github.com/avanzzzi/hypy/wiki
 
+## Window resizing on Linux/Mac
+On Linux and Mac, hypy passes `/smart-sizing` to xfreerdp, so the VM window can be freely resized. The image will scale to fit the window without black areas.
+
+For **true dynamic resolution** (the VM display actually changes resolution to match the window size), Hyper-V Enhanced Session must be enabled on the host. Run the following on the Windows Hyper-V host as Administrator:
+
+```powershell
+Set-VMHost -EnableEnhancedSessionMode $true
+# or
+Set-VM -VMName "YourVMName" -EnhancedSessionTransportType HvSocket
+```
+
+> **Note:** Linux guest VMs also require `xrdp` installed inside the VM to support Enhanced Session.
+
+Once Enhanced Session is active, replace `/smart-sizing` with `/dynamic-resolution` in `hypy/modules/hvclient.py` for the best experience.
+
 ## tests
 A tox.ini file is included for execution of style check and unit tests.

--- a/hypy/modules/hvclient.py
+++ b/hypy/modules/hvclient.py
@@ -27,7 +27,8 @@ def connect(vm_id: str, vm_name: str, vm_index: str):
     passw = config['pass']
     host = config['host']
 
-    if platform.uname()[0] == "Windows":
+    is_windows = platform.uname()[0] == "Windows"
+    if is_windows:
         freerdp_bin = "wfreerdp.exe"
     else:
         freerdp_bin = "xfreerdp"
@@ -38,6 +39,9 @@ def connect(vm_id: str, vm_name: str, vm_index: str):
                         '/p:{}'.format(passw),
                         '/t:{} [{}] {}'.format(host, vm_index, vm_name),
                         '/cert-ignore']
+
+    if not is_windows:
+        cmd.append('/smart-sizing')
 
     try:
         handle = Popen(cmd, stdout=DEVNULL, stderr=PIPE)


### PR DESCRIPTION
 Add /smart-sizing flag to xfreerdp command on Linux/Mac so the VM
 window can be resized without black areas. The VM image scales to
 fill the window client-side.

 Document the limitation in README: for true dynamic resolution (VM
 re-renders at the new size), Hyper-V Enhanced Session must be enabled
 on the host. Include PowerShell instructions and a note about xrdp
 requirement for Linux guests