### PR TITLE
fix: remove double b64decode of password in hvclient

### DIFF
--- a/hypy/modules/hvclient.py
+++ b/hypy/modules/hvclient.py
@@ -24,7 +24,7 @@ def connect(vm_id: str, vm_name: str, vm_index: str):
         vm_index: Index of the vm in the cache file.
     """
     user = config['user']
-    passw = b64decode(config['pass'])
+    passw = config['pass']
     host = config['host']
 
     if platform.uname()[0] == "Windows":
@@ -350,7 +350,7 @@ def run_cmd_ssh(cmd: str) -> Response:
     ssh_client.load_system_host_keys()
     ssh_client.set_missing_host_key_policy(AutoAddPolicy())
     ssh_client.connect(username=config['user'],
-                       password=b64decode(config['pass']),
+                       password=config['pass'],
                        hostname=config['host'],
                        port=int(config['ssh_port']),
                        allow_agent=False,
@@ -380,7 +380,7 @@ def run_cmd_winrm(cmd: str) -> Response:
                       transport='ntlm',
                       username=r'{}\{}'.format(config['domain'],
                                                config['user']),
-                      password=b64decode(config['pass']),
+                      password=config['pass'],
                       server_cert_validation='ignore')
 
     shell_id = client.open_shell()

--- a/hypy/modules/hvclient.py
+++ b/hypy/modules/hvclient.py
@@ -25,7 +25,11 @@ def connect(vm_id: str, vm_name: str, vm_index: str):
     """
     user = config['user']
     passw = config['pass']
+    domain = config['domain']
     host = config['host']
+
+    if isinstance(passw, bytes):
+        passw = passw.decode('utf-8')
 
     if platform.uname()[0] == "Windows":
         freerdp_bin = "wfreerdp.exe"
@@ -34,7 +38,7 @@ def connect(vm_id: str, vm_name: str, vm_index: str):
 
     cmd = [freerdp_bin, '/v:{}'.format(host),
                         '/vmconnect:{}'.format(vm_id),
-                        '/u:{}'.format(user),
+                        '/u:{}'.format(r'{}\{}'.format(domain, user)),
                         '/p:{}'.format(passw),
                         '/t:{} [{}] {}'.format(host, vm_index, vm_name),
                         '/cert:ignore']


### PR DESCRIPTION
## Summary

- `config.load()` already decodes the base64 password and stores the plain bytes in `config['pass']`
- The subsequent `b64decode()` calls in `connect()`, `run_cmd_ssh()` and `run_cmd_winrm()` were decoding an already decoded value
- This caused `binascii.Error: Incorrect padding` when trying to connect to a VM