### PR TITLE
update version from paramiko to 3^ to avoid warning algorithms.TripleDES

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "hypy"}]
 python = "^3.5"
 pywinrm = "^0.3.0"
 click = "^7.0"
-paramiko = "^2.6"
+paramiko = "^3.0"
 asciitree = "^0.3.3"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
When running any command on hypy it`s show an warning : 
 ➜  ~ hypy switch get 35
~/.virtualenvs/hypy/lib/python3.12/site-packages/paramiko/pkey.py:82: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from cryptography.hazmat.primitives.ciphers.algorithms in 48.0.0.
  "cipher": algorithms.TripleDES,
~/.virtualenvs/hypy/lib/python3.12/site-packages/paramiko/transport.py:253: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from cryptography.hazmat.primitives.ciphers.algorithms in 48.0.0.
  "class": algorithms.TripleDES,
VMName                         SwitchName
VMNAME-01         SWITCHNAME-01

The update on paramiko is to avoid this!